### PR TITLE
Correct the trailing syntax problem

### DIFF
--- a/syntax/tmux.vim
+++ b/syntax/tmux.vim
@@ -50,25 +50,25 @@ syn keyword tmuxOptsSet prefix prefix2 status status-fg status-bg bell-action
 syn keyword tmuxOptsSet default-command history-limit status-left status-right
 syn keyword tmuxOptsSet status-interval set-titles display-time buffer-limit
 syn keyword tmuxOptsSet status-left-length status-right-length status-position
-syn keyword tmuxOptsSet message-[command-]bg lock-after-time assume-paste-time 
-syn keyword tmuxOptsSet message-[command-]attr status-attr set-remain-on-exit
+syn keyword tmuxOptsSet message-[command-] bg lock-after-time assume-paste-time
+syn keyword tmuxOptsSet message-[command-] attr status-attr set-remain-on-exit
 syn keyword tmuxOptsSet status-utf8 default-terminal visual-activity repeat-time
 syn keyword tmuxOptsSet visual-bell visual-content status-justify status-keys
 syn keyword tmuxOptsSet terminal-overrides status-left-attr status-left-bg
 syn keyword tmuxOptsSet status-left-fg status-right-attr status-right-bg
 syn keyword tmuxOptsSet status-right-fg update-environment base-index
 syn keyword tmuxOptsSet display-panes-colour display-panes-time default-shell
-syn keyword tmuxOptsSet set-titles-string lock-command lock-server status-style 
+syn keyword tmuxOptsSet set-titles-string lock-command lock-server status-style
 syn keyword tmuxOptsSet mouse-select-pane message-limit quiet escape-time
 syn keyword tmuxOptsSet pane-active-border-bg pane-active-border-fg
-syn keyword tmuxOptsSet pane-border-bg pane-border-fg message-[command-]fg
+syn keyword tmuxOptsSet pane-border-bg pane-border-fg message-[command-] fg
 syn keyword tmuxOptsSet display-panes-active-colour alternate-screen
-syn keyword tmuxOptsSet detach-on-destroy word-separators message-[command-]style 
+syn keyword tmuxOptsSet detach-on-destroy word-separators message-[command-] style
 syn keyword tmuxOptsSet destroy-unattached exit-unattached set-clipboard
 syn keyword tmuxOptsSet bell-on-alert mouse-select-window mouse-utf8
-syn keyword tmuxOptsSet mouse-resize-pane pane-active-border-style 
-syn keyword tmuxOptsSet message-[command-]fg renumber-windows visual-silence
-syn keyword tmuxOptsSet pane-border-style status-left-style status-right-style focus-events 
+syn keyword tmuxOptsSet mouse-resize-pane pane-active-border-style
+syn keyword tmuxOptsSet message-[command-] fg renumber-windows visual-silence
+syn keyword tmuxOptsSet pane-border-style status-left-style status-right-style focus-events
 
 syn keyword tmuxOptsSetw monitor-activity aggressive-resize force-width
 syn keyword tmuxOptsSetw force-height remain-on-exit uft8 mode-fg mode-bg
@@ -79,21 +79,21 @@ syn keyword tmuxOptsSetw main-pane-width main-pane-height monitor-content
 syn keyword tmuxOptsSetw window-status-current-attr window-status-current-bg
 syn keyword tmuxOptsSetw window-status-current-fg mode-mouse synchronize-panes
 syn keyword tmuxOptsSetw window-status-format window-status-current-format
-syn keyword tmuxOptsSetw window-status-activity-attr mode-style wrap-search 
+syn keyword tmuxOptsSetw window-status-activity-attr mode-style wrap-search
 syn keyword tmuxOptsSetw window-status-activity-bg window-status-activity-fg
 syn keyword tmuxOptsSetw window-status-bell-attr window-status-activity-style
 syn keyword tmuxOptsSetw window-status-bell-bg window-status-bell-fg
-syn keyword tmuxOptsSetw window-status-content-attr window-status-content-style 
+syn keyword tmuxOptsSetw window-status-content-attr window-status-content-style
 syn keyword tmuxOptsSetw window-status-content-bg window-status-content-fg
 syn keyword tmuxOptsSetw pane-base-index other-pane-height other-pane-width
 syn keyword tmuxOptsSetw allow-rename c0-change-interval c0-change-trigger
 syn keyword tmuxOptsSetw layout-history-limit monitor-silence utf8 wrap-search
 syn keyword tmuxOptsSetw automatic-rename-format monitor-silence window-status-bell-style
 syn keyword tmuxOptsSetw window-status-last-style window-status-separator
-syn keyword tmuxOptsSetw window-status-current-style window-status-style 
+syn keyword tmuxOptsSetw window-status-current-style window-status-style
 
-syn keyword tmuxLayoutName even-horizontal even-vertical 
-syn keyword tmuxLayoutName main-horizontal main-vertical tiled 
+syn keyword tmuxLayoutName even-horizontal even-vertical
+syn keyword tmuxLayoutName main-horizontal main-vertical tiled
 
 syn keyword tmuxTodo FIXME NOTE TODO XXX contained
 


### PR DESCRIPTION
- After a `]` the plugin needs a space before the next command.
In the actual release, because of it, when you open a file on vim, the vim show various errors.
- After this fix, never see this anymore.